### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/muffin-os/muffin/security/code-scanning/5](https://github.com/muffin-os/muffin/security/code-scanning/5)

To fix the problem, you should explicitly set a `permissions` block in your workflow YAML file. The best place for this is the top level of the workflow, which default-applies the permission set to all jobs unless overridden per job. This ensures that the GITHUB_TOKEN used for jobs in the workflow has the minimum required permissions. For this workflow, at minimum `contents: read` is appropriate: all jobs using `actions/checkout` or `actions/upload-artifact` only need read access to repository contents.

Add the following block near the start of the file (after the workflow name, before `on` or `env`):

```yaml
permissions:
  contents: read
```

This block should be added directly after `name: Rust`, making it clear and effective for all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
